### PR TITLE
fix TypeError: Population must be a sequence.

### DIFF
--- a/src/dokusan/generators.py
+++ b/src/dokusan/generators.py
@@ -31,7 +31,7 @@ def _random_initial_cells(box_size: BoxSize) -> List[Cell]:
     size = box_size.width * box_size.length
     all_values = set(range(1, size + 1))
 
-    values = random.sample(sorted(all_values), k=size)
+    values = random.sample(list(all_values), k=size)
     box_values = [
         values[i * box_size.length : i * box_size.length + box_size.length]
         for i in range(box_size.width)

--- a/src/dokusan/generators.py
+++ b/src/dokusan/generators.py
@@ -31,20 +31,20 @@ def _random_initial_cells(box_size: BoxSize) -> List[Cell]:
     size = box_size.width * box_size.length
     all_values = set(range(1, size + 1))
 
-    values = random.sample(all_values, k=size)
+    values = random.sample(sorted(all_values), k=size)
     box_values = [
         values[i * box_size.length : i * box_size.length + box_size.length]
         for i in range(box_size.width)
     ]
 
     while True:  # pragma: no branch
-        row_values = random.sample(all_values - set(box_values[0]), k=box_size.length)
+        row_values = random.sample(sorted(all_values - set(box_values[0])), k=box_size.length)
         used_values = [sorted(box_values[i]) for i in range(1, box_size.width)]
         if sorted(row_values) not in used_values:
             break
 
-    row_values += random.sample(
-        all_values.difference(box_values[0], row_values), k=box_size.length
+    row_values += random.sample(sorted(
+        all_values.difference(box_values[0], row_values)), k=box_size.length
     )
 
     return [
@@ -61,3 +61,4 @@ def _random_initial_cells(box_size: BoxSize) -> List[Cell]:
         )
         for i, value in enumerate(row_values, start=box_size.length)
     ]
+


### PR DESCRIPTION
Hello!

Running [this game](https://github.com/MarioMatsas/SudokuGame) on Python 3.11 gives me the error "TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).", as seen below: 


> % python3 game.py
> pygame 2.3.0 (SDL 2.24.2, Python 3.11.2)
> Hello from the pygame community. https://www.pygame.org/contribute.html
> Traceback (most recent call last):
>   File "/Users/basil/Developer/temp/SudokuGame/SudokuGame/game.py", line 17, in <module>
>     board = sudoku_generator.generateBoard(difficulty)
>             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>   File "/Users/basil/Developer/temp/SudokuGame/SudokuGame/sudoku_generator.py", line 5, in generateBoard
>     boardValues = str(generators.random_sudoku(avg_rank=difficulty))
>                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>   File "/opt/homebrew/lib/python3.11/site-packages/dokusan/generators.py", line 11, in random_sudoku
>     sudoku = Sudoku(*_random_initial_cells(box_size), box_size=box_size)
>                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>   File "/opt/homebrew/lib/python3.11/site-packages/dokusan/generators.py", line 34, in _random_initial_cells
>     values = random.sample(all_values, k=size)
>              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>   File "/opt/homebrew/Cellar/python@3.11/3.11.2_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/random.py", line 439, in sample
>     raise TypeError("Population must be a sequence.  "
> TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).


The small changes in this pull request seem to fix it: after making them, it runs without errors.